### PR TITLE
LifeCycle hooks

### DIFF
--- a/src/app/task-dialog-reactive/task-dialog-reactive.component.html
+++ b/src/app/task-dialog-reactive/task-dialog-reactive.component.html
@@ -6,7 +6,7 @@
   <mat-dialog-content class="form-class">
     <mat-form-field appearance="fill">
       <mat-label>Task Name</mat-label>
-      <input matInput formControlName="taskName" />
+      <input matInput formControlName="taskName" #taskNameInput />
       <mat-error *ngIf="taskForm.get('taskName')?.hasError('required')">
         Task Name is required
       </mat-error>

--- a/src/app/task-dialog-reactive/task-dialog-reactive.component.ts
+++ b/src/app/task-dialog-reactive/task-dialog-reactive.component.ts
@@ -1,5 +1,12 @@
 import { CommonModule } from '@angular/common';
-import { Component, Inject, OnInit } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  Inject,
+  OnInit,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
 import {
   FormBuilder,
   FormGroup,
@@ -36,6 +43,7 @@ import { MatIconModule } from '@angular/material/icon';
 })
 export class TaskDialogReactiveComponent implements OnInit {
   taskForm!: FormGroup;
+  @ViewChild('taskNameInput') taskNameInput!: ElementRef;
 
   constructor(
     private fb: FormBuilder,
@@ -97,4 +105,28 @@ export class TaskDialogReactiveComponent implements OnInit {
   closeDialog(): void {
     this.dialogRef.close(null);
   }
+
+  ngAfterViewInit(): void {
+    this.taskNameInput.nativeElement.focus();
+  }
+
+  ngDoCheck(): void {
+    if (this.taskForm.get('taskName')?.dirty) {
+      console.log('Task name has been modified.');
+    }
+  }
+  ngAfterContentChecked(): void {
+    const tagsArray = this.taskForm.get('tags') as FormArray;
+
+    if (tagsArray.length > 3) {
+      console.log('Too many tags!');
+    }
+  }
+  // ngAfterViewChecked(): void {
+  //   const hasErrors =
+  //     this.taskForm.get('taskName')?.hasError('required') ||
+  //     this.taskForm.get('taskDescription')?.hasError('required');
+
+  //   console.log('Error state changed:', hasErrors);
+  // }
 }

--- a/src/app/task-dialog/task-dialog.component.html
+++ b/src/app/task-dialog/task-dialog.component.html
@@ -18,6 +18,7 @@
           required
           placeholder="Enter task title"
           #taskName="ngModel"
+          #taskNameInput
         />
         <mat-error *ngIf="taskName.invalid && taskName.touched">
           Title is required.

--- a/src/app/task-dialog/task-dialog.component.ts
+++ b/src/app/task-dialog/task-dialog.component.ts
@@ -5,6 +5,7 @@ import {
   Output,
   EventEmitter,
   ViewEncapsulation,
+  SimpleChanges,
 } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { CommonModule } from '@angular/common';
@@ -68,5 +69,15 @@ export class TaskDialogComponent {
 
   ngOnInit() {
     this.initialTask = JSON.stringify(this.task);
+  }
+
+  ngAfterContentInit(): void {
+    console.log('Content has been initialized');
+    const taskNameInput = document.querySelector(
+      '#taskNameInput'
+    ) as HTMLInputElement;
+    if (taskNameInput) {
+      taskNameInput.focus();
+    }
   }
 }


### PR DESCRIPTION
### Common Lifecycle Hooks

- ngOnInit

Called once after the component is initialized.
Use it to perform component initialization, such as fetching data from APIs or initializing properties.


- ngOnChanges

Called whenever an input property value changes.
Use it to react to changes in @Input bindings.


- ngDoCheck

Called during every change detection cycle.
Use it for custom change detection logic.


- ngAfterContentInit

Called once after the component's content (e.g., <ng-content>) has been projected into the view.


- ngAfterContentChecked


Called after every check of the projected content.


- ngAfterViewInit


Called once after the component's view (and child views) has been initialized.
Useful for working with DOM elements or child components.


- ngAfterViewChecked


Called after every check of the component's view (and child views).


- ngOnDestroy

Called once just before the component is destroyed.
Use it to clean up resources like subscriptions or event listeners.
